### PR TITLE
Add simple David vs. Audrey scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# d-vs-a
+# David vs. Audrey Scoreboard
+
+A simple static website for tracking scores between David and Audrey. Built with HTML, CSS, and a bit of JavaScript. Games and scores are stored in the browser's local storage so the page can be hosted using GitHub Pages.
+
+## Usage
+
+1. Open `index.html` in a browser.
+2. Click **Add Game** to create a new game entry.
+3. Use the **+** and **-** buttons under each player to adjust scores.
+
+All data is saved in the browser's local storage.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>David vs. Audrey Scoreboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>David vs. Audrey</h1>
+  </header>
+  <main>
+    <div id="games"></div>
+    <button id="add-game">Add Game</button>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,73 @@
+let games = JSON.parse(localStorage.getItem('games') || '[]');
+
+function saveGames() {
+  localStorage.setItem('games', JSON.stringify(games));
+}
+
+function renderGames() {
+  const container = document.getElementById('games');
+  container.innerHTML = '';
+
+  games.forEach((game, index) => {
+    const gameDiv = document.createElement('div');
+    gameDiv.className = 'game';
+
+    const title = document.createElement('h2');
+    title.textContent = game.name;
+    gameDiv.appendChild(title);
+
+    const scores = document.createElement('div');
+    scores.className = 'scores';
+
+    ['david', 'audrey'].forEach(player => {
+      const playerDiv = document.createElement('div');
+      playerDiv.className = 'player';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = player.charAt(0).toUpperCase() + player.slice(1);
+      playerDiv.appendChild(nameSpan);
+
+      const scoreDiv = document.createElement('div');
+      scoreDiv.textContent = game[player];
+      scoreDiv.id = `score-${index}-${player}`;
+      playerDiv.appendChild(scoreDiv);
+
+      const controls = document.createElement('div');
+      controls.className = 'controls';
+
+      const plus = document.createElement('button');
+      plus.textContent = '+';
+      plus.addEventListener('click', () => updateScore(index, player, 1));
+      controls.appendChild(plus);
+
+      const minus = document.createElement('button');
+      minus.textContent = '-';
+      minus.addEventListener('click', () => updateScore(index, player, -1));
+      controls.appendChild(minus);
+
+      playerDiv.appendChild(controls);
+      scores.appendChild(playerDiv);
+    });
+
+    gameDiv.appendChild(scores);
+    container.appendChild(gameDiv);
+  });
+}
+
+function updateScore(index, player, delta) {
+  games[index][player] = Math.max(0, games[index][player] + delta);
+  saveGames();
+  document.getElementById(`score-${index}-${player}`).textContent = games[index][player];
+}
+
+function addGame() {
+  const name = prompt('Enter game name:');
+  if (!name) return;
+  games.push({ name, david: 0, audrey: 0 });
+  saveGames();
+  renderGames();
+}
+
+document.getElementById('add-game').addEventListener('click', addGame);
+
+renderGames();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,89 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: 'Poppins', sans-serif;
+}
+
+body {
+  background: #f4f4f8;
+  color: #333;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+header {
+  width: 100%;
+  background: #4a90e2;
+  color: #fff;
+  text-align: center;
+  padding: 1rem 0;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+main {
+  width: 90%;
+  max-width: 600px;
+  margin-top: 2rem;
+}
+
+.game {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.game h2 {
+  font-size: 1.1rem;
+  flex: 1;
+}
+
+.scores {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.player {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.player span {
+  font-weight: 600;
+}
+
+.controls {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  border: none;
+  background: #4a90e2;
+  color: #fff;
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+button:hover {
+  background: #357ab7;
+}
+
+#add-game {
+  width: 100%;
+  padding: 0.8rem;
+  font-size: 1rem;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Create single-page scoreboard with modern Poppins font and responsive layout.
- Allow adding games and adjusting David and Audrey scores with plus/minus buttons.
- Store game data in browser local storage for persistence.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fc9effa8832797d47376c5170f67