### PR TITLE
Tidy scoreboard controls

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,25 +46,20 @@ function renderGames() {
       nameSpan.textContent = player.charAt(0).toUpperCase() + player.slice(1);
       playerDiv.appendChild(nameSpan);
 
+      const scoreRow = document.createElement('div');
+      scoreRow.className = 'score-row';
+
       const scoreDiv = document.createElement('div');
       scoreDiv.textContent = game[player];
       scoreDiv.id = `score-${index}-${player}`;
-      playerDiv.appendChild(scoreDiv);
-
-      const controls = document.createElement('div');
-      controls.className = 'controls';
+      scoreRow.appendChild(scoreDiv);
 
       const plus = document.createElement('button');
       plus.textContent = '+';
       plus.addEventListener('click', () => updateScore(index, player, 1));
-      controls.appendChild(plus);
+      scoreRow.appendChild(plus);
 
-      const minus = document.createElement('button');
-      minus.textContent = '-';
-      minus.addEventListener('click', () => updateScore(index, player, -1));
-      controls.appendChild(minus);
-
-      playerDiv.appendChild(controls);
+      playerDiv.appendChild(scoreRow);
       scores.appendChild(playerDiv);
     });
 

--- a/style.css
+++ b/style.css
@@ -61,9 +61,10 @@ main {
   font-weight: 600;
 }
 
-.controls {
+.score-row {
   margin-top: 0.5rem;
   display: flex;
+  align-items: center;
   gap: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Remove decrement control from scoreboard and keep only plus increment button
- Align increment button inline with score value for each player

## Testing
- `node --check d-vs-a/script.js`
- `node --check d-vs-a/api/scoreboard.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1210b3fb083278d8675367a0e5d1d